### PR TITLE
(fix) Do not throw when passed props with undefined values

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35,7 +35,7 @@ exports.options = options;
 function doSetAttribute(el, props, propName) {
   if (propName === 'className') {
     el.setAttribute('class', props.className);
-  } else if (props[propName].constructor === Function) {
+  } else if (typeof props[propName] === 'undefined' || props[propName].constructor === Function) {
     return;
   } else {
     el.setAttribute(propName, props[propName]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -33,12 +33,14 @@ exports.options = options;
  */
 
 function doSetAttribute(el, props, propName) {
+  var prop = props[propName];
+
   if (propName === 'className') {
     el.setAttribute('class', props.className);
-  } else if (typeof props[propName] === 'undefined' || props[propName].constructor === Function) {
+  } else if (typeof prop === 'undefined' || prop === null || prop.constructor === Function) {
     return;
   } else {
-    el.setAttribute(propName, props[propName]);
+    el.setAttribute(propName, prop);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,12 +11,14 @@ export {options};
  * Call `.setAttribute()` on the `ref`, passing prop data directly to A-Frame.
  */
 function doSetAttribute (el, props, propName) {
+  const prop = props[propName];
+
   if (propName === 'className') {
     el.setAttribute('class', props.className);
-  } else if (typeof props[propName] === 'undefined' || props[propName].constructor === Function) {
+  } else if (typeof prop === 'undefined' || prop === null || prop.constructor === Function) {
     return;
   } else {
-    el.setAttribute(propName, props[propName]);
+    el.setAttribute(propName, prop);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ export {options};
 function doSetAttribute (el, props, propName) {
   if (propName === 'className') {
     el.setAttribute('class', props.className);
-  } else if (props[propName].constructor === Function) {
+  } else if (typeof props[propName] === 'undefined' || props[propName].constructor === Function) {
     return;
   } else {
     el.setAttribute(propName, props[propName]);

--- a/tests/browser/index.test.js
+++ b/tests/browser/index.test.js
@@ -236,9 +236,10 @@ suite('<Entity primitive/>', () => {
     });
   });
 
-  test('does not set attributes with undefined values', () => {
-    ReactDOM.render(<Scene><Entity example={undefined}/></Scene>, div);
-    assert.notEqual(div.querySelector('a-entity').getAttribute('example'), 'undefined');
+  test('does not set attributes with undefined or null values', () => {
+    ReactDOM.render(<Scene><Entity undefined={undefined} null={null}/></Scene>, div);
+    assert.notEqual(div.querySelector('a-entity').getAttribute('undefined'), 'undefined');
+    assert.notEqual(div.querySelector('a-entity').getAttribute('null'), 'null');
   });
 
   test('can take single-property boolean component as boolean', () => {

--- a/tests/browser/index.test.js
+++ b/tests/browser/index.test.js
@@ -235,6 +235,25 @@ suite('<Entity primitive/>', () => {
       done();
     });
   });
+
+  test('does not set attributes with undefined values', () => {
+    ReactDOM.render(<Scene><Entity example={undefined}/></Scene>, div);
+    assert.notEqual(div.querySelector('a-entity').getAttribute('example'), 'undefined');
+  });
+
+  test('can take single-property boolean component as boolean', () => {
+    ReactDOM.render(<Scene truevalue={true} falsevalue={false}/>, div);
+    const scene = div.querySelector('a-scene');
+    assert.equal(scene.getAttribute('truevalue'), 'true');
+    assert.equal(scene.getAttribute('falsevalue'), 'false');
+  });
+
+  test('can take single-property boolean component as string', () => {
+    ReactDOM.render(<Scene truevalue="true" falsevalue="false"/>, div);
+    const scene = div.querySelector('a-scene');
+    assert.equal(scene.getAttribute('truevalue'), 'true');
+    assert.equal(scene.getAttribute('falsevalue'), 'false');
+  });
 });
 
 suite('<Entity events/>', () => {
@@ -319,24 +338,6 @@ suite('<Entity events/>', () => {
         assert.ok(barHandlerCalled);
         done();
       });
-    });
-  });
-});
-
-suite('<Scene/>', () => {
-  test('can take single-property boolean component as boolean', done => {
-    ReactDOM.render(<Scene embedded={true}/>, div);
-    div.querySelector('a-scene').addEventListener('loaded', () => {
-      assert.ok(div.querySelector('a-scene').getAttribute('embedded'));
-      done();
-    });
-  });
-
-  test('can take single-property boolean component as string', done => {
-    ReactDOM.render(<Scene embedded="true"/>, div);
-    div.querySelector('a-scene').addEventListener('loaded', () => {
-      assert.ok(div.querySelector('a-scene').getAttribute('embedded'));
-      done();
     });
   });
 });


### PR DESCRIPTION
Ran into an issue where I was wrapping a component with React Router's `withRouter`, which was passing in a prop with a value of `undefined`. This caused the `constructor === Function` check in `doSetAttribute` to throw, as undefined does not have a constructor property. Added in a check to avoid throwing.

Reworked tests a little - let me know if you want me to review changes. Made the boolean checks more generic and to also check for false values, as I initially implemented my check with `!props[propsName]`, which didn't `setAttribute` on false values.