### PR TITLE
(fix) Prevent doSetAttribute throw on null or undefined prop

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35,7 +35,7 @@ exports.options = options;
 function doSetAttribute(el, props, propName) {
   if (propName === 'className') {
     el.setAttribute('class', props.className);
-  } else if (props[propName].constructor === Function) {
+  } else if (props[propName] && props[propName].constructor === Function) {
     return;
   } else {
     el.setAttribute(propName, props[propName]);

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ export {options};
 function doSetAttribute (el, props, propName) {
   if (propName === 'className') {
     el.setAttribute('class', props.className);
-  } else if (props[propName].constructor === Function) {
+  } else if (props[propName] && props[propName].constructor === Function) {
     return;
   } else {
     el.setAttribute(propName, props[propName]);

--- a/tests/browser/index.test.js
+++ b/tests/browser/index.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {Entity, Scene} from '../../src/index.js';
+import {Entity, doSetAttribute, Scene} from '../../src/index.js';
 
 const div = document.createElement('div');
 document.body.appendChild(div);
@@ -235,6 +235,13 @@ suite('<Entity primitive/>', () => {
       done();
     });
   });
+
+  test('supports null or undefined props', () => {
+    ReactDOM.render(<Scene undefined={undefined} null={null} />, div);
+    const scene = div.querySelector('a-scene');
+    assert.equal(scene.getAttribute('undefined'), 'undefined');
+    assert.equal(scene.getAttribute('null'), 'null');
+  });
 });
 
 suite('<Entity events/>', () => {
@@ -325,17 +332,21 @@ suite('<Entity events/>', () => {
 
 suite('<Scene/>', () => {
   test('can take single-property boolean component as boolean', done => {
-    ReactDOM.render(<Scene embedded={true}/>, div);
-    div.querySelector('a-scene').addEventListener('loaded', () => {
-      assert.ok(div.querySelector('a-scene').getAttribute('embedded'));
+    ReactDOM.render(<Scene true={true} false={false}/>, div);
+    const scene = div.querySelector('a-scene');
+    scene.addEventListener('loaded', () => {
+      assert.equal(scene.getAttribute('true'), 'true');
+      assert.equal(scene.getAttribute('false'), 'false');
       done();
     });
   });
 
   test('can take single-property boolean component as string', done => {
-    ReactDOM.render(<Scene embedded="true"/>, div);
-    div.querySelector('a-scene').addEventListener('loaded', () => {
-      assert.ok(div.querySelector('a-scene').getAttribute('embedded'));
+    ReactDOM.render(<Scene true="true" false="false"/>, div);
+    const scene = div.querySelector('a-scene');
+    scene.addEventListener('loaded', () => {
+      assert.equal(scene.getAttribute('true'), 'true');
+      assert.equal(scene.getAttribute('false'), 'false');
       done();
     });
   });


### PR DESCRIPTION
Ran into an issue where I was wrapping a component with React Router's withRouter, which was passing in a prop with a value of undefined. This caused the constructor === Function check in doSetAttribute to throw, as undefined (and null) do not have a constructor property. Added in a check to avoid throwing.

Reworked tests a little - let me know if you want me to review changes. Made the boolean checks more generic and to also check for false values, as my initial fix didn't account for falsey values.